### PR TITLE
fix: installation of dependencies on Windows

### DIFF
--- a/packages/umbra_cli/lib/src/commands/install_deps.dart
+++ b/packages/umbra_cli/lib/src/commands/install_deps.dart
@@ -39,7 +39,12 @@ class InstallDepsCommand extends UmbraCommand {
   @override
   Future<int> run() async {
     final checkingDependencies = logger.progress('Checking dependencies');
-    final glslc = File.fromUri(dataDirectory.uri.resolve('bin/glslc'));
+    var programExtension = '';
+    if (platform.isWindows) {
+      programExtension = '.exe';
+    }
+    final glslc =
+        File.fromUri(dataDirectory.uri.resolve('bin/glslc$programExtension'));
     if (glslc.existsSync()) {
       checkingDependencies.fail();
       logger.err('Dependencies are already installed');
@@ -51,7 +56,8 @@ class InstallDepsCommand extends UmbraCommand {
     downloadingDeps.complete('Dependencies downloaded');
 
     final extractingDeps = logger.progress('Extracting dependencies');
-    final fileBytes = await _extractor.extract('install/bin/glslc', archive);
+    final fileBytes =
+        await _extractor.extract('install/bin/glslc$programExtension', archive);
     extractingDeps.complete('Dependencies extracted');
 
     final installingDeps = logger.progress('Installing dependencies');

--- a/packages/umbra_cli/test/src/commands/install_deps_test.dart
+++ b/packages/umbra_cli/test/src/commands/install_deps_test.dart
@@ -211,10 +211,11 @@ void main() {
 
         verify(() => logger.progress('Extracting dependencies')).called(1);
         verify(
-          () => extractor.extract('install/bin/glslc', archiveBytes),
+          () => extractor.extract('install/bin/glslc.exe', archiveBytes),
         ).called(1);
         verify(
-          () => writer.write('/C/Users/test/.umbra/bin/glslc', expectedBytes),
+          () =>
+              writer.write('/C/Users/test/.umbra/bin/glslc.exe', expectedBytes),
         ).called(1);
         verifyNever(() => cmd.run('chmod', any()));
       });


### PR DESCRIPTION
## Description

Installing the dependencies was giving me the following error:
`
Bad state: No element
#0      ListMixin.firstWhere (dart:collection/list.dart:167:5)
#1      FileExtractor.extract (package:umbra_cli/src/workers/file_extractor.dart:26:26) ...
`

I managed to track the problem to the fact that the FileExtractor was expecting a file named "install/bin/glslc" in the archive, but the actual name is "install/bin/glslc.exe" (for Windows). Also, the file was being saved as "glslc" and not as "glslc.exe", as it should on Windows.

I just added the ".exe" to the end of the file names, when installing the dependencies and the platform is Windows. Creating and generating the shaders is working for me now.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
