### PR TITLE
feat: show contextual message on command usage exceptions

### DIFF
--- a/packages/umbra_cli/lib/src/commands/create/create.dart
+++ b/packages/umbra_cli/lib/src/commands/create/create.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:args/command_runner.dart';
 import 'package:mason/mason.dart' hide packageVersion;
 import 'package:umbra_cli/src/commands/create/templates/templates.dart';
 import 'package:umbra_cli/src/umbra_command.dart';
@@ -64,7 +63,7 @@ class CreateCommand extends UmbraCommand {
   String get _fileName {
     final rest = results.rest;
     if (rest.isEmpty || rest.first.isEmpty) {
-      throw UsageException('No name specified.', usage);
+      usageException('No name specified.');
     }
     return rest.first;
   }
@@ -75,9 +74,8 @@ class CreateCommand extends UmbraCommand {
         : Directory(results['output'] as String);
 
     if (!directory.existsSync()) {
-      throw UsageException(
+      usageException(
         'Directory "${directory.path}" does not exist.',
-        usage,
       );
     }
     return directory;

--- a/packages/umbra_cli/lib/src/commands/generate/generate.dart
+++ b/packages/umbra_cli/lib/src/commands/generate/generate.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:args/command_runner.dart';
 import 'package:mason/mason.dart' hide packageVersion;
 import 'package:path/path.dart' as path;
 import 'package:umbra/umbra.dart';
@@ -67,11 +66,11 @@ class GenerateCommand extends UmbraCommand {
   File get _shaderFile {
     final rest = results.rest;
     if (rest.isEmpty || rest.first.isEmpty) {
-      throw UsageException('No file specified.', usage);
+      usageException('No file specified.');
     }
     final shaderFile = File(rest.first);
     if (!shaderFile.existsSync()) {
-      throw UsageException('File "${shaderFile.path}" does not exist.', usage);
+      usageException('File "${shaderFile.path}" does not exist.');
     }
     return shaderFile;
   }
@@ -84,10 +83,7 @@ class GenerateCommand extends UmbraCommand {
     );
 
     if (!directory.existsSync()) {
-      throw UsageException(
-        'Directory "${directory.path}" does not exist.',
-        usage,
-      );
+      usageException('Directory "${directory.path}" does not exist.');
     }
     return directory;
   }

--- a/packages/umbra_cli/lib/src/umbra_command_runner.dart
+++ b/packages/umbra_cli/lib/src/umbra_command_runner.dart
@@ -71,7 +71,7 @@ class UmbraCommandRunner extends CommandRunner<int> {
       _logger
         ..err(e.message)
         ..info('')
-        ..info(usage);
+        ..info(e.usage);
       return ExitCode.usage.code;
     }
   }

--- a/packages/umbra_cli/test/src/umbra_command_runner_test.dart
+++ b/packages/umbra_cli/test/src/umbra_command_runner_test.dart
@@ -99,7 +99,7 @@ void main() {
       });
 
       test('handles UsageException', () async {
-        final exception = UsageException('oops!', commandRunner.usage);
+        final exception = UsageException('oops!', 'exception usage');
         var isFirstInvocation = true;
         when(() => logger.info(any())).thenAnswer((_) {
           if (isFirstInvocation) {
@@ -110,7 +110,7 @@ void main() {
         final result = await commandRunner.run(['--version']);
         expect(result, equals(ExitCode.usage.code));
         verify(() => logger.err(exception.message)).called(1);
-        verify(() => logger.info(commandRunner.usage)).called(1);
+        verify(() => logger.info('exception usage')).called(1);
       });
 
       test(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When a usage exception occurs inside a lead command, the CLI currently outputs the from the root command with description. This PR changes to show a more contextual error message.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
